### PR TITLE
Add python dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,6 +52,9 @@ in haskellPackages.developPackage {
       cp dist/build/timelog-periods/timelog-periods $out/bin
       cp dist/build/process-hours/process-hours $out/bin
     '';
+
+    # Required for org2tc
+    executableSystemDepends = [ pkgs.python ];
   });
 
   inherit returnShellEnv;


### PR DESCRIPTION
I needed this patch on NixOS; on other distros, the python dependency is probably implicit (included in `/usr/bin` or whatever).